### PR TITLE
Feat update page title

### DIFF
--- a/frontend/src/components/Breadcrumbs.jsx
+++ b/frontend/src/components/Breadcrumbs.jsx
@@ -51,10 +51,12 @@ export const Breadcrumbs = () => {
       }
 
       setBreadcrumbLabels(labels);
+      const modelName = Object.values(labels)[0];
+      const instanceName = Object.values(labels).pop();
+      document.title = `${instanceName} - ${modelName} - Model Explorer`;
     };
-
     updateLabels();
-  }, [location]);
+  }, [location, document.title]);
 
   const visible_pathnames = [
     breadcrumbLabels['/'],

--- a/frontend/src/views/HomeView.jsx
+++ b/frontend/src/views/HomeView.jsx
@@ -21,6 +21,7 @@ export const HomeView = () => {
         const response = await fetch(API_BASE_URL + '/model-info');
         const data = await response.json();
         setModelInfo(data);
+        document.title = `${data.title} - Model Explorer`;
       } catch (err) {
         setError('Failed to fetch model info: ' + err.message);
       }


### PR DESCRIPTION
The page title now updates based on the view. 

- When in HomeView the page title now shows 'model name' - Model explorer
- When in InsanceView before selecting any element the title shows 'layer name' - 'model name'  - Model Explorer
- When selecting an element in InsanceView the title shows 'instance name' - 'model name' - Model Explorer
- Page also maintains title when reloading/hard reloading the content

closes: #8 