### PR TITLE
fix: Correctly enable scrollbar plugin and use it in the right place

### DIFF
--- a/frontend/src/components/InstanceView.jsx
+++ b/frontend/src/components/InstanceView.jsx
@@ -70,9 +70,7 @@ export const InstanceView = ({ templateName, objectID, endpoint }) => {
     <>
       <div
         ref={contentRef}
-        className="html-content scrollbar scrollbar-track-gray-200
-          scrollbar-thumb-gray-400 dark:scrollbar-track-custom-dark-3
-          dark:scrollbar-thumb-slate-600 svg-display mb-4 rounded-lg border-4
+        className="html-content svg-display mb-4 rounded-lg border-4
           border-transparent bg-gray-100 p-8 text-gray-700 shadow-lg
           hover:border-gray-300 hover:shadow-md dark:bg-custom-dark-2
           dark:text-gray-100 dark:shadow-dark md:w-[210mm] print:m-0

--- a/frontend/src/views/TemplateView.jsx
+++ b/frontend/src/views/TemplateView.jsx
@@ -79,7 +79,10 @@ export const TemplateView = ({ endpoint }) => {
         </div>
 
         <main>
-          <div className="overflow-y-auto md:w-screen">
+          <div
+            className="overflow-y-auto scrollbar scrollbar-track-gray-200
+              scrollbar-thumb-gray-400 dark:scrollbar-track-custom-dark-3
+              dark:scrollbar-thumb-slate-600">
             {!objectID && !singleObjectID && (
               <p
                 className={`absolute left-1/2 top-1/2 -translate-x-1/2

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,6 +2,7 @@
  * Copyright DB InfraGO AG and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+import tailwindScrollbar from 'tailwind-scrollbar';
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -35,5 +36,5 @@ export default {
       }
     }
   },
-  plugins: ['tailwind-scrollbar']
+  plugins: [tailwindScrollbar()]
 };


### PR DESCRIPTION
Fix the scrollbar plugin for tailwind being loaded incorrectly and apply its classes to the correct element.

Closes #51