### PR TITLE
Fix template syntax errors

### DIFF
--- a/templates/__generic__.html.j2
+++ b/templates/__generic__.html.j2
@@ -8,7 +8,7 @@
 {% if object.name %}
 <h1>{{ object.name }} <span style="font-size: 60%">({{ object.__class__.__name__ }})</span></h1>
 {% else %}
-<h1>Unnamed ({{ object.__class__.__name__ }})</small></h1>
+<h1>Unnamed ({{ object.__class__.__name__ }})</h1>
 {% endif %}
 
 {{show_other_attributes(object) | safe}}

--- a/templates/common_macros.html.j2
+++ b/templates/common_macros.html.j2
@@ -168,7 +168,6 @@
                 {{req_rels(req.relations, scope=scope) | safe}}
                 {{show_other_attributes(req, excluded=["related", "relations", "requirements", "text", "owner", "validate", "xtype"], hide_rules_check=True, hide_unset_attrs=True) | safe}}
             </td>
-        </div>
         </tr>
     {% endfor %}
     </table>

--- a/templates/cross-cutting/region.html.j2
+++ b/templates/cross-cutting/region.html.j2
@@ -45,19 +45,21 @@ Upon completion of all entry activities of <i>{{ render_name_with_icon(tx.source
 </ul>
 {% endif %}
 
-{% if state.entry %}
-<p>On entry into the <b>{{ state.name }}</b> {{ state.__class__.__name__ }} the system shall perform the following activities:
-{% for fnc in state.entry %}
+{% if state.entries %}
+<p>
+On entry into the <b>{{ state.name }}</b> {{ state.__class__.__name__ }} the system shall perform the following activities:
+{% for fnc in state.entries %}
 {{ render_name_with_icon(fnc) | safe }};
-{% endfor %}</p>
+{% endfor %}
+</p>
 {% endif %}
 
 {% if state.do_activity %}
-<p>While in <b>{{ state.name }}</b> {{ state.__class__.__name__ }} the system may perform the following activities: </p>
+<p>While in <b>{{ state.name }}</b> {{ state.__class__.__name__ }} the system may perform the following activities:</p>
 <ul>
 {% for fnc in state.do_activity %}
 <li>{{ render_name_with_icon(fnc) | safe }} </li>
-{% endfor %}</p>
+{% endfor %}
 </ul>
 {% endif %}
 

--- a/templates/functional.html.j2
+++ b/templates/functional.html.j2
@@ -108,7 +108,7 @@
 <p>The function is available in the following states of the {{ owner | safe }}:</p>
 <ul>
     {% for state in object.available_in_states %}
-        <li>{{linked_name_with_icon(state) | safe}}</a></li>
+        <li>{{linked_name_with_icon(state) | safe}}</li>
     {% endfor %}
 </ul>
 {% else %}

--- a/templates/logical-architecture/logical-component.html.j2
+++ b/templates/logical-architecture/logical-component.html.j2
@@ -15,7 +15,7 @@ The figure below provides an overview of the logical subsystem and external enti
 
 {{ object.context_diagram.as_svg|safe }}
 
-<h3>Logical interface partners of {{object.name}}</h2>
+<h3>Logical interface partners of {{object.name}}</h3>
 
 {% set lexcs = [] %}{% for port in object.ports %}{% for lexc in port.exchanges %}
 {% set _ = lexcs.append([lexc, lexc.source.owner if lexc.source.owner != subsystem else lexc.target.owner]) %}

--- a/templates/logical-architecture/logical-state.html.j2
+++ b/templates/logical-architecture/logical-state.html.j2
@@ -30,19 +30,21 @@ Upon completion of all entry activities of <i>{{ render_name_with_icon(tx.source
 </ul>
 {% endif %}
 
-{% if object.entry %}
-<p>On entry into the <b>{{ object.name }}</b> {{ object.__class__.__name__ }} the system shall perform the following activities:
-{% for fnc in object.entry %}
+{% if object.entries %}
+<p>
+On entry into the <b>{{ object.name }}</b> {{ object.__class__.__name__ }} the system shall perform the following activities:
+{% for fnc in object.entries %}
 {{ render_name_with_icon(fnc) | safe }};
-{% endfor %}</p>
+{% endfor %}
+</p>
 {% endif %}
 
 {% if object.do_activity %}
-<p>While in <b>{{ object.name }}</b> {{ object.__class__.__name__ }} the system may perform the following activities: </p>
+<p>While in <b>{{ object.name }}</b> {{ object.__class__.__name__ }} the system may perform the following activities:</p>
 <ul>
 {% for fnc in object.do_activity %}
 <li>{{ render_name_with_icon(fnc) | safe }} </li>
-{% endfor %}</p>
+{% endfor %}
 </ul>
 {% endif %}
 

--- a/templates/object_comparison.html.j2
+++ b/templates/object_comparison.html.j2
@@ -51,7 +51,7 @@
     {% if object.name %}
         <h1>{{ object.name }} <span style="font-size: 60%">({{ object.__class__.__name__ }})</span></h1>
     {% else %}
-        <h1>Unnamed ({{ object.__class__.__name__ }})</small></h1>
+        <h1>Unnamed ({{ object.__class__.__name__ }})</h1>
     {% endif %}
     {{show_other_attributes(object, object_diff, display_modified_changes=display_modified_changes) | safe}}
 {% else %}

--- a/templates/system-analysis/mod-rules-compliance.html.j2
+++ b/templates/system-analysis/mod-rules-compliance.html.j2
@@ -41,7 +41,6 @@
   {% endif -%}
 {% endmacro -%}
 
-</head>
 <body>
 <h1>Modeling Rules Compliance Report for System Analysis Layer</h1>
 <p>
@@ -66,7 +65,7 @@
   {% if total != 0 %}
     <p><span style="color: {{color}}">{{score}}%</span> <small>({{passed}} / {{total}} rule checks)</small> for {{category}} rules category</p>
   {% else %}
-    <p><span style="color: #ccc">No rules in {{category}} category apply to objects under evaluation.</p>
+    <p><span style="color: #ccc">No rules in {{category}} category apply to objects under evaluation.</span></p>
   {% endif -%}
 {% endfor %}
 
@@ -102,8 +101,10 @@
 <table>
 <thead>
   <tr>
-    <th width="160px">Rule
-    <th>Definition
+    <th width="160px">Rule</th>
+    <th>Definition</th>
+  </tr>
+  </thead>
   <tbody>
     {% for rule in results.iter_rules() | sort(attribute="id") | sort(attribute="category.value") -%}
     {% set rule_results = results.by_rule(rule) -%}

--- a/templates/system-analysis/system-actor.html.j2
+++ b/templates/system-analysis/system-actor.html.j2
@@ -15,7 +15,7 @@
     <b>{{ object.name }}</b>
 </h1>
 {% else %}
-<h1>Unnamed ({{ object.__class__.__name__ }})</small></h1>
+<h1>Unnamed ({{ object.__class__.__name__ }})</h1>
 {% endif %}
 
 {{ description(object) | safe }}

--- a/templates/system-analysis/system-interface.html.j2
+++ b/templates/system-analysis/system-interface.html.j2
@@ -25,7 +25,7 @@
 {% if object.name %}
 <h1>{{ object.name }} <span style="font-size: 60%">({{ object.__class__.__name__ }})</span></h1>
 {% else %}
-<h1>Unnamed ({{ object.__class__.__name__ }})</small></h1>
+<h1>Unnamed ({{ object.__class__.__name__ }})</h1>
 {% endif %}
 
 {% set source_provides = [] %}


### PR DESCRIPTION
The syntax errors were identified with the help of the `https://github.com/davidodenwald/prettier-plugin-jinja-template` plugin