### PR TITLE
Restore "Electrical Interfaces" table for Physical Components

### DIFF
--- a/templates/physical-architecture/phy-component.html.j2
+++ b/templates/physical-architecture/phy-component.html.j2
@@ -6,6 +6,7 @@
   from 'common_macros.html.j2' import
   description,
   display_property_label,
+  display_property_values,
   linked_name_with_icon,
   render_allocated_functions,
   render_capability_section,
@@ -37,6 +38,45 @@
 {% set interfaces = object.related_exchanges %}
 {% set exchange_items_catalog = [] %}
 {{ render_interfaces_section(object, interfaces, exchange_items_catalog) | safe }}
+<h2>Electrical interfaces of {{ object.name }}</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Port</th>
+      <th>Cable ID</th>
+      <th>Target</th>
+      <th>Target Port</th>
+    </tr>
+  </thead>
+  <tbody>
+    {%- for port in object.physical_ports %}
+      {%- set cables = port.links %}
+      {%- if cables %}
+        {%- for cable in cables %}
+          <tr>
+            {%- set other_port = cable.ends | reject("equalto", port) | first %}
+            {%- if loop.first %}
+              <td rowspan="{{ cables | length }}">
+                {{ linked_name_with_icon(port) | safe }}
+              </td>
+            {%- endif %}
+            <td>{{ linked_name_with_icon(cable) | safe }}</td>
+            <td>{{ linked_name_with_icon(other_port.owner) | safe }}</td>
+            <td>{{ linked_name_with_icon(other_port) | safe }}</td>
+          </tr>
+        {%- endfor %}
+      {%- else %}
+        <tr>
+          <td>{{ linked_name_with_icon(port) | safe }}</td>
+          <td colspan="3">No cable connections planned</td>
+        </tr>
+      {%- endif %}
+    {%- endfor %}
+  </tbody>
+</table>
+
+{{ display_property_values(object) | safe }}
 
 {% if exchange_items_catalog %}
   <h2>Apendix A: Exchange Items Catalog</h2>


### PR DESCRIPTION
Restore the table from 5d6aa1902549dfb91cc7c49c3ab16867d2380a9a, after which it accidentally got deleted during a larger template rewrite.