### PR TITLE
Migrate CLI from argparse to click

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN uv venv && \
 
 # install Node pkgs and build the CSS {{{
 RUN npm clean-install && \
-  uv run python3 -m capella_model_explorer build css && \
+  uv run python3 -m capella_model_explorer build && \
   rm -rf node_modules
 # }}}
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ pip install capella-model-explorer
 ## Run the app
 
 The app comes with a command line interface (CLI).
-Command `cme -h` to get help or `cme SUBCOMMAND -h` to get help for any
+Command `cme --help` to get help or `cme SUBCOMMAND --help` to get help for any
 subcommand.
 
 ```bash
-cme run -h
+cme run --help
 ```
 
-lists the available run options.
+explains the available run options.
 
 In all cases the running app will be served at a location (default:
 `http://localhost:8000`) that will be printed to the console.
@@ -64,8 +64,8 @@ cme run
 ### Build a Docker image and run the app in a container
 
 ```bash
-cme build image
-cme run --container
+docker build -t capella-model-explorer .
+cme run --container --image capella-model-explorer
 ```
 
 Above will start the app with a sample model which can be found here:

--- a/capella_model_explorer/app.py
+++ b/capella_model_explorer/app.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import pathlib
-import sys
 import tempfile
 import time
 import traceback
@@ -27,20 +26,16 @@ from capella_model_explorer import components, core, reports, state
 logger = logging.getLogger("uvicorn")
 core.setup_logging(logger)
 
-logger.info("Configuration:")
-logger.info("\tRoute prefix: '%s'", c.ROUTE_PREFIX)
-logger.info("\tLive mode: %s", c.LIVE_MODE)
-logger.info("\tHost: '%s'", c.HOST)
-logger.info("\tCapella model: '%s'", c.MODEL)
-logger.info("\tTemplates directory: '%s'", c.TEMPLATES_DIR)
-
-if c.ROUTE_PREFIX and not c.ROUTE_PREFIX.startswith("/"):
-    logger.error("Invalid route prefix: %r", c.ROUTE_PREFIX)
-    sys.exit(1)
-
 
 @contextlib.asynccontextmanager
 async def lifespan(_):
+    logger.info("Configuration:")
+    logger.info("\tRoute prefix: '%s'", c.ROUTE_PREFIX)
+    logger.info("\tLive mode: %s", c.LIVE_MODE)
+    logger.info("\tHost: '%s'", c.HOST)
+    logger.info("\tCapella model: '%s'", c.MODEL)
+    logger.info("\tTemplates directory: '%s'", c.TEMPLATES_DIR)
+
     model_spec = capellambse.loadinfo(c.MODEL)
     logger.info("Loading model from: %s", model_spec["path"])
     state.model = capellambse.MelodyModel(**model_spec)

--- a/capella_model_explorer/constants.py
+++ b/capella_model_explorer/constants.py
@@ -12,7 +12,6 @@ import fasthtml.starlette
 from fasthtml import common as fh
 from fasthtml import ft
 
-import capella_model_explorer as cme
 from capella_model_explorer import core
 
 CONFIG = fasthtml.starlette.Config(env_prefix="CME_")
@@ -20,9 +19,7 @@ CONFIG = fasthtml.starlette.Config(env_prefix="CME_")
 
 @dataclasses.dataclass
 class Defaults:
-    docker_image_name: t.Final[str] = (
-        f"capella-model-explorer:{cme.__version__}"
-    )
+    docker_image_name: t.Final[str] = "capella-model-explorer:latest"
     host: t.Final[str] = "0.0.0.0"
     live_mode: bool = True
     model: t.Final[str] = (

--- a/capella_model_explorer/core.py
+++ b/capella_model_explorer/core.py
@@ -44,10 +44,15 @@ class ColoredFormatter(logging.Formatter):
 
 
 def setup_logging(logger: logging.Logger):
-    logging.getLogger("uvicorn").setLevel("INFO")
+    logger.setLevel("INFO")
     formatter = ColoredFormatter(
         "%(asctime)s.%(msecs)03d|%(levelname)-8s | %(message)s",
         datefmt="%Y-%m-%d|%H:%M:%S",
     )
-    for handler in logger.handlers:
-        handler.setFormatter(formatter)
+    if not logger.hasHandlers():
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
+    else:
+        for handler in logger.handlers:
+            handler.setFormatter(formatter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ classifiers = [
 dependencies = [
   "capellambse-context-diagrams>=0.7.3,<0.8",
   "capellambse>=0.6.13,<0.7",
-  "jinja2",
-  "prometheus-client",
-  "python-fasthtml",
-  "uvicorn",
+  "jinja2>=3.1.5,<4",
+  "prometheus-client>=0.21.1,<0.22",
+  "python-fasthtml>=0.12.1,<0.13",
+  "uvicorn>=0.34.0,<0.35",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
   "capellambse-context-diagrams>=0.7.3,<0.8",
   "capellambse>=0.6.13,<0.7",
+  "click>=8.1.8,<9",
   "jinja2>=3.1.5,<4",
   "prometheus-client>=0.21.1,<0.22",
   "python-fasthtml>=0.12.1,<0.13",


### PR DESCRIPTION
A suggestion for the CLI. Using click we get the whole description and how to use and helpful text for free:
```bash
$ cme run --help
Usage: cme run [OPTIONS]

  Run the application.

Options:
  --container           Launch as a Docker container.
  --dev                 Launch in development mode with full auto-reload. This
                        option cannot be used together with --container.
  --host TEXT           The hostname or IP address to bind to. Ignored when
                        running with '--container'.  [default: 0.0.0.0]
  --port INTEGER        The port to listen on.  [default: 8000]
  --model TEXT          The Capella model to load (file, URL or JSON string).
                        [default: git+https://github.com/DSD-DBS/Capella-IFE-
                        sample.git]
  --templates-dir TEXT  The directory containing the templates.   [default:
                        /home/liyuanxin/wörk/capella-model-explorer/templates]
  --live-mode [0|1]     Control automatic reloading of templates on changes.
                        Set to 1 to enable, 0 to disable. Ignored in '--dev'
                        mode.  [default: 1]
  --route-prefix TEXT   Add a prefix to all web routes. (Note: this prefix
                        does not apply to '/metrics').  [default: ""]
  --image TEXT          The Docker image to use with '--container'.
                        [default: capella-model-explorer:0.2.7.dev17]
  --help                Show this message and exit.
  ```
  
Also with the last commit I made the options to actually work/update the `constants.CONFIG`. And I noticed that there are no version limits set in the pyproject.toml. My initial run gave me errors because I had an old version of fasthml installed. Since some dependencies are still in 0.x we should limit them cautiously.