### PR TITLE
Cache rendered reports of Git models for a year

### DIFF
--- a/capella_model_explorer/app.py
+++ b/capella_model_explorer/app.py
@@ -149,7 +149,7 @@ def rendered_report(template_id: str, model_element_uuid: str = "") -> t.Any:
                 cls="dark:text-neutral-100 grow content-center",
             )
         )
-    return components.template_container(
+    content = components.template_container(
         ft.Div(
             fh.NotStr(rendered_template),
             ft.Script(
@@ -158,6 +158,12 @@ def rendered_report(template_id: str, model_element_uuid: str = "") -> t.Any:
             ),
             cls="prose svg-display dark:prose-invert",
         )
+    )
+    max_age = 31536000 if state.model.info.resources["\x00"].rev_hash else 0
+    return (
+        content,
+        fh.HttpHeader(k="Cache-Control", v=f"max-age={max_age}"),
+        fh.HttpHeader(k="Vary", v="Render-Environment"),
     )
 
 


### PR DESCRIPTION
In the case of a model maintained in a Git repository, a rendered report
will be loaded from the cache as long it is not more than a year old or
there is a change for any out of the following:

- the model element UUID (which is part of the URL)
- the template file
- the version of the capella-model-explorer
- the version of the capellambse library
- the version of the capellambse-context-diagrams library
- the model revision

Note, that non-Git model versions cannot be distinguished reliably in
the cache. Therefore, rendered reports for non-Git are not cached at
all.