### PR TITLE
Always rebuild the CSS before running

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@
 
 export CME_TEMPLATES_DIR="/templates"
 . /app/.venv/bin/activate
-exec cme run
+exec cme run --skip-rebuild


### PR DESCRIPTION
When running from a source tree in non-dev mode, the built CSS may still become stale. With this commit, the CSS will always be rebuilt before launching, unless the `--skip-build` flag was passed. Note that even with `--skip-build`, the CSS will still be built initially if it doesn't exist at all yet.