### PR TITLE
Enable HTMX boost mode

### DIFF
--- a/capella_model_explorer/components.py
+++ b/capella_model_explorer/components.py
@@ -28,21 +28,24 @@ def application_shell(
 ) -> tuple[ft.Title, ft.Main]:
     return (
         ft.Title(f"{state.model.name} - Model Explorer"),
-        ft.Main(
-            page_header(),
-            content,
-            # placeholder for script injection per outerHTML swap
-            ft.Script(id="script"),
-            id="root",
-            cls=(
-                "bg-neutral-100",
-                "dark:bg-neutral-900",
-                "flex",
-                "flex-col",
-                "h-screen",
-                "min-h-screen",
-                f"place-items-{align}",
+        ft.Body(
+            ft.Main(
+                page_header(),
+                content,
+                # placeholder for script injection per outerHTML swap
+                ft.Script(id="script"),
+                id="root",
+                cls=(
+                    "bg-neutral-100",
+                    "dark:bg-neutral-900",
+                    "flex",
+                    "flex-col",
+                    "h-screen",
+                    "min-h-screen",
+                    f"place-items-{align}",
+                ),
             ),
+            hx_boost="true",
         ),
     )
 


### PR DESCRIPTION
When we put hx-boost on the <body> element with the value true, it will "boost" all anchor and form elements within that element. "Boost", here, means that htmx will convert all those anchors and forms from "normal" hypermedia controls into AJAX-powered hypermedia controls.

With a boosted link, the browser is able to avoid any processing associated with the head tag. The head tag often contains many scripts and CSS file references. In the boosted scenario, it is not necessary to re-process those resources: the scripts and styles have already been processed and will continue to apply to the new content. This can often be a very easy way to speed up your hypermedia application.

see also:

https://hypermedia.systems/htmx-patterns/#_ajax_ifying_our_application