### PR TITLE
Disable HTMX boost mode again

### DIFF
--- a/capella_model_explorer/components.py
+++ b/capella_model_explorer/components.py
@@ -28,24 +28,21 @@ def application_shell(
 ) -> tuple[ft.Title, ft.Main]:
     return (
         ft.Title(f"{state.model.name} - Model Explorer"),
-        ft.Body(
-            ft.Main(
-                page_header(),
-                content,
-                # placeholder for script injection per outerHTML swap
-                ft.Script(id="script"),
-                id="root",
-                cls=(
-                    "bg-neutral-100",
-                    "dark:bg-neutral-900",
-                    "flex",
-                    "flex-col",
-                    "h-screen",
-                    "min-h-screen",
-                    f"place-items-{align}",
-                ),
+        ft.Main(
+            page_header(),
+            content,
+            # placeholder for script injection per outerHTML swap
+            ft.Script(id="script"),
+            id="root",
+            cls=(
+                "bg-neutral-100",
+                "dark:bg-neutral-900",
+                "flex",
+                "flex-col",
+                "h-screen",
+                "min-h-screen",
+                f"place-items-{align}",
             ),
-            hx_boost="true",
         ),
     )
 


### PR DESCRIPTION
Boosting causes issues with the current client-side scripting, as discussed in #137. Disable it again to work around those issues. This should be revisited in the future.

This reverts commit eecaf956f379ef279b43bdbe62a53f1fd95e349e.