### PR TITLE
Improve layouting of tables with wide columns

### DIFF
--- a/static/css/input.css
+++ b/static/css/input.css
@@ -87,7 +87,9 @@ html.dark .svg-display svg:not(.main-svg):not(.icon) {
 .html-content table tr th {
   vertical-align: top;
   padding: 0 0.4em;
-  word-break: break-word;
+  white-space: normal;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 .html-content table tr td:first-of-type,
 .html-content table tr th:first-of-type {


### PR DESCRIPTION
In the Functional Interface Spec tables can run into a case with multiple rowspans. In that case the current wrapping behavior can turn to the right most column displaying just 2 letters. This fixes it in the tailwind input CSS.