### PR TITLE
Disable live mode in docker by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV HOME=/home
 ENV PATH=$HOME/.local/bin:/app/bin:$PATH
 ENV VIRTUAL_ENV=/app
 ENV MODEL_ENTRYPOINT=/model
+ENV CME_LIVE_MODE=0
 EXPOSE 8000
 
 RUN apt-get update && \


### PR DESCRIPTION
While this doesn't entirely fix the issue, it will prevent containers in a default setup from stalling indefinitely.

Resolves #155