### PR TITLE
Add a helper envvar to keep the loading spinner spinning

### DIFF
--- a/capella_model_explorer/__main__.py
+++ b/capella_model_explorer/__main__.py
@@ -339,6 +339,13 @@ def main(
     default=False,
     help="Don't rebuild already existing assets.",
 )
+@click.option(
+    "--debug-spinner",
+    envvar="CME_DEBUG_SPINNER",
+    is_flag=True,
+    default=False,
+    help="Keep the template loading spinner spinning until clicked",
+)
 @click.pass_context
 def run(
     ctx: click.Context,
@@ -354,6 +361,7 @@ def run(
     route_prefix: str,
     image: str,
     skip_rebuild: bool,
+    debug_spinner: bool,
 ) -> None:
     """Run the application."""
     os.environ["CME_HOST"] = host
@@ -363,6 +371,7 @@ def run(
     os.environ["CME_LIVE_MODE"] = "1" if live_mode else "0"
     os.environ["CME_ROUTE_PREFIX"] = route_prefix
     os.environ["CME_DOCKER_IMAGE_NAME"] = image
+    os.environ["CME_DEBUG_SPINNER"] = "01"[debug_spinner]
     importlib.reload(c)
 
     if container and dev:

--- a/capella_model_explorer/components.py
+++ b/capella_model_explorer/components.py
@@ -14,6 +14,7 @@ from fasthtml import ft, svg
 
 import capella_model_explorer
 from capella_model_explorer import app, core, icons, reports, state
+from capella_model_explorer import constants as c
 
 
 def application_shell(
@@ -326,7 +327,7 @@ def report_placeholder(
 
         ph_content = ft.Div(
             icons.spinner(),
-            hx_trigger="load",
+            hx_trigger="click" if c.DEBUG_SPINNER else "load",
             hx_get=app.rendered_report.to(
                 template_id=template.id,
                 model_element_uuid=model_element_uuid,

--- a/capella_model_explorer/constants.py
+++ b/capella_model_explorer/constants.py
@@ -32,6 +32,8 @@ class Defaults:
     templates_dir: t.Final[pathlib.Path] = pathlib.Path("templates")
 
 
+DEBUG_SPINNER = CONFIG("DEBUG_SPINNER", cast=bool, default=False)
+
 DOCKER_IMAGE_NAME: str = CONFIG(
     "DOCKER_IMAGE_NAME", default=Defaults.docker_image_name
 )


### PR DESCRIPTION
This introduces a new environment variable `CME_DEBUG_SPINNER`, which prevents the template placeholder / spinner from actually fetching the rendered template contents. This greatly helps with debugging the layout of said spinner.