### PR TITLE
Enable calculating the version number in Docker builds

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -120,6 +120,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Since #167, the model explorer version number is shown on the main page. However, for CI-built docker images, this always shows "v0.1.dev1", because the Git history is not available by default.

This commit instructs the CI to make a tree-less partial clone instead of a shallow clone for the Docker build job, which allows setuptools-scm to calculate the correct version number.