### PR TITLE
Correctly report app version in built Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ RUN curl -fsSL https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(whi
 COPY . /build
 
 WORKDIR /build
-RUN uv run cme build
+RUN git restore -- Dockerfile && \
+  uv run cme build
 
 RUN uv venv /app && \
   uv pip compile pyproject.toml >requirements.txt && \


### PR DESCRIPTION
A "COPY . /somewhere" instruction in a Dockerfile does not copy the Dockerfile itself. This caused setuptools-scm inside the build container to erroneously see a dirty worktree, leading it to generate a `X.Y.dev0` version instead of the expected (and desired) `X.Y`.

This commit fixes the issue by restoring the Dockerfile from the git index before starting the app build in the container.